### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ of hot reloading.
 ## Folder structure
  * `/litecord` contains the actual litecord server code.
  * `/utils` has utilities to use within litecord code.
- * `/docs` has documentation on how the server actually does its stuff.
+ * `/doc` has documentation on how the server actually does its stuff.
  * `/boilerplate_data`, [read this](https://git.memework.org/lnmds/litecord/src/master/boilerplate_data/README.md)
  * Depending on your installation, you might have a `/env` directory,
  **DON'T MESS WITH IT.**, don't install other libraries unless otherwise specified(pls don't break your server instance).


### PR DESCRIPTION
/docs isn't a directory, but /doc is!